### PR TITLE
Refactor double buffering

### DIFF
--- a/src/main/scala/gemm/BatchGemmSnaxTop.scala
+++ b/src/main/scala/gemm/BatchGemmSnaxTop.scala
@@ -38,46 +38,80 @@ class BatchGemmSnaxTop(TCDMWritePorts: Int = 8) extends BatchGemm {
   // signals for keep sending request until q_ready
   val read_fire = WireInit(false.B)
   val keep_read = RegInit(false.B)
-  val write_fire = WireInit(false.B)
-  val keep_write = RegInit(false.B)
 
-  // signals for indicating when to stall
-  // stall after reading K matrix until writing current output is ready
-  val stalled_by_write_reg = RegInit(false.B)
+  // signals for indicating when to shift
+  // shift after reading K matrix
   val K = RegInit(0.U(GemmConstant.sizeConfigWidth.W))
-  val read_rsp_counter = RegInit(0.U(24.W))
-  val start_stall_counter = WireInit(false.B)
-
-  val output_done = WireInit(false.B)
-  val output_start = WireInit(false.B)
+  val read_rsp_counter = RegInit(0.U((3 * GemmConstant.sizeConfigWidth).W))
+  val k_read_rsp_done = WireInit(false.B)
 
   // number of stage to output the result
   val stages = GemmConstant.idealTCDMWritePorts / TCDMWritePorts
 
-  // signals for indicating output progress
-  val output_counter = RegInit(0.U(log2Ceil(stages).W))
-  // indicating if we are output result matrix
-  val output_state = RegInit(0.U(1.W))
-  val new_output_ready = WireInit(false.B)
-  val new_output_fire = WireInit(false.B)
-
-  // regs to store data and address when output in multi-cycle or waiting for q_ready
-  val output_reg = RegInit(
-    0.U(((stages) * TCDMWritePorts * GemmConstant.TCDMDataWidth).W)
-  )
-  val addr_c = RegInit(0.U(GemmConstant.addrWidth.W))
-
-  // regs to store input matrix address fro keep sending request when waiting for the q_ready
+  // registers to store input submatrix address for keep sending request when waiting for the q_ready
   val addr_a = RegInit(0.U(GemmConstant.addrWidth.W))
   val addr_b = RegInit(0.U(GemmConstant.addrWidth.W))
 
-  // for generating the address in multi cycle output
+  // check if the register to store current result (current computation process) is ready to decide stall read or not
+  val is_ping_output_for_read = WireInit(0.B)
+  val is_pong_output_for_read = WireInit(0.B)
+  val is_ping_output_for_read_reg = RegInit(1.B)
+  val is_pong_output_for_read_reg = RegInit(0.B)
+
+  // double registers to store data and address when output in multi-cycle or waiting for output reg ready
+  // the ping/pong double buffering strategy
+  val data_c_reg_ping = RegInit(
+    0.U(((stages) * TCDMWritePorts * GemmConstant.TCDMDataWidth).W)
+  )
+  val data_c_reg_pong = RegInit(
+    0.U(((stages) * TCDMWritePorts * GemmConstant.TCDMDataWidth).W)
+  )
+  val addr_c_reg_ping = RegInit(0.U(GemmConstant.addrWidth.W))
+  val addr_c_reg_pong = RegInit(0.U(GemmConstant.addrWidth.W))
+
+  // ready/valid signal for each output data and address register to handshake between
+  // inputting results from the GEMM and outputting to TCDM
+  val output_reg_ready_ping = WireInit(1.B)
+  val output_reg_ready_pong = WireInit(1.B)
+  val output_reg_valid_ping = RegInit(0.B)
+  val output_reg_valid_pong = RegInit(0.B)
+
+  // indicating which output data and address register to receiving current result from GEMM
+  val is_ping_output_for_write = WireInit(1.B)
+  val is_pong_output_for_write = WireInit(0.B)
+  val is_ping_output_for_write_reg = RegInit(1.B)
+  val is_pong_output_for_write_reg = RegInit(0.B)
+
+  // indicating which output data and address register is writing to TCDM
+  val is_ping_writing = RegInit(1.B)
+  val is_pong_writing = RegInit(0.B)
+
+  // write fire signals, only assert when io.ctrl.valid and io.ctrl.ready are asserted together
+  val ping_write_fire = WireInit(false.B)
+  val pong_write_fire = WireInit(false.B)
+  val write_fire = WireInit(false.B)
+
+  // indicating from block gemm point of view, the output is done
+  val ping_new_output_fire = WireInit(false.B)
+  val pong_new_output_fire = WireInit(false.B)
+  val new_output_fire = WireInit(false.B)
+
+  // signals for indicating output progress
+  val output_done = WireInit(false.B)
+  val output_start = WireInit(false.B)
+  val output_counter = RegInit(0.U(log2Ceil(stages).W))
+
+  // indicating if we are output result matrix
+  // this is related to the ready signal for ping/pong buffering
+  val ping_output_state = RegInit(0.B)
+  val pong_output_state = RegInit(0.B)
+
+  // for generating the address in multi cycle output for submatrix c
   def addrDelta =
     TCDMWritePorts * GemmConstant.TCDMDataWidth / GemmConstant.dataWidthPerAddr
 
-  // when output_valid_multi_stages is asserted, the output data valid is asserted too
-  def output_valid_multi_stages = output_state =/= 0.U
-
+  // gemm_write_valid_from_block_gemm asserts until it get a ready signal
+  // which means al least the GEMM result is written to one of the double buffering
   val gemm_write_valid_from_block_gemm =
     controller.io.gemm_write_valid_o || keep_gemm_write_valid_o
 
@@ -99,27 +133,86 @@ class BatchGemmSnaxTop(TCDMWritePorts: Int = 8) extends BatchGemm {
     read_rsp_counter := 0.U
   }
 
-  // stall after reading K matrix back
-  start_stall_counter := read_rsp_counter === K - 1.U && io.ctrl.data_valid_i === 1.B
+  // when get k read responds, shift the ping/pong buffer for stalling reading
+  k_read_rsp_done := read_rsp_counter === K - 1.U && io.ctrl.data_valid_i === 1.B
 
-  // stall after reading K matrix, no need to stall when outputting current result matrix, because we have double buffering
-  when(start_stall_counter) {
-    stalled_by_write_reg := 1.B
-  }.elsewhen(output_start) {
-    stalled_by_write_reg := 0.B
+  when(k_read_rsp_done) {
+    is_ping_output_for_read := ~is_ping_output_for_read_reg
+    is_pong_output_for_read := ~is_pong_output_for_read_reg
+  }.otherwise {
+    is_ping_output_for_read := is_ping_output_for_read_reg
+    is_pong_output_for_read := is_pong_output_for_read_reg
   }
+  is_ping_output_for_read_reg := is_ping_output_for_read
+  is_pong_output_for_read_reg := is_pong_output_for_read
 
-  controller.io.stalled_by_write := start_stall_counter || (stalled_by_write_reg && ~output_start) || (!new_output_ready && (gemm_write_valid_from_block_gemm))
+  dontTouch(controller.io.stalled_by_write)
+  // controller.io.stalled_by_write := ((ping_new_output_fire || !output_reg_ready_ping) && is_ping_output_for_read) || ((pong_new_output_fire || !output_reg_ready_pong) && is_pong_output_for_read)
+  controller.io.stalled_by_write := ((!output_reg_ready_ping) && is_ping_output_for_read) || ((!output_reg_ready_pong) && is_pong_output_for_read)
 
+  // shift the ping/pong buffer for writing the results form GEMM
+  new_output_fire := ping_new_output_fire || pong_new_output_fire
   when(new_output_fire) {
-    output_state := 1.U
-  }.elsewhen(
-    output_state === 1.U && output_done
-  ) {
-    output_state := 0.U
+    is_ping_output_for_write := ~is_ping_output_for_write_reg
+    is_pong_output_for_write := ~is_pong_output_for_write_reg
+  }.otherwise {
+    is_ping_output_for_write := is_ping_output_for_write_reg
+    is_pong_output_for_write := is_pong_output_for_write_reg
+  }
+  is_ping_output_for_write_reg := is_ping_output_for_write
+  is_pong_output_for_write_reg := is_pong_output_for_write
+
+  // storing io.data.c_o when it is valid for later output according to if it is ping or pong
+  // for ping buffer
+  ping_write_fire := io.ctrl.gemm_write_valid_o && io.ctrl.write_mem_ready && is_ping_writing
+  ping_new_output_fire := output_reg_ready_ping && gemm_write_valid_from_block_gemm && is_ping_output_for_write_reg
+  // right shift the result data to support only output the lowest part of bits every time without changing the index
+  when(ping_write_fire && ping_new_output_fire) {
+    data_c_reg_ping := io.data.c_o >> (TCDMWritePorts * GemmConstant.TCDMDataWidth).U
+  }.elsewhen(!ping_write_fire && ping_new_output_fire) {
+    data_c_reg_ping := io.data.c_o
+  }.elsewhen(ping_write_fire) {
+    data_c_reg_ping := data_c_reg_ping >> (TCDMWritePorts * GemmConstant.TCDMDataWidth).U
   }
 
-  // output_counter for multi stage output
+  // store the address and extra data for later output
+  when(ping_new_output_fire) {
+    addr_c_reg_ping := block_gemm_addr_c_o
+  }
+
+  // for pong buffer
+  pong_write_fire := io.ctrl.gemm_write_valid_o && io.ctrl.write_mem_ready && is_pong_writing
+  pong_new_output_fire := output_reg_ready_pong && gemm_write_valid_from_block_gemm && is_pong_output_for_write_reg
+  when(pong_write_fire && pong_new_output_fire) {
+    data_c_reg_pong := io.data.c_o >> (TCDMWritePorts * GemmConstant.TCDMDataWidth).U
+  }.elsewhen(!pong_write_fire && pong_new_output_fire) {
+    data_c_reg_pong := io.data.c_o
+  }.elsewhen(pong_write_fire) {
+    data_c_reg_pong := data_c_reg_pong >> (TCDMWritePorts * GemmConstant.TCDMDataWidth).U
+  }
+
+  when(pong_new_output_fire) {
+    addr_c_reg_pong := block_gemm_addr_c_o
+  }
+
+  // designing ping/pong output state change
+  when(ping_new_output_fire) {
+    ping_output_state := 1.U
+  }.elsewhen(
+    ping_output_state === 1.U && output_done && is_ping_writing
+  ) {
+    ping_output_state := 0.U
+  }
+
+  when(pong_new_output_fire) {
+    pong_output_state := 1.U
+  }.elsewhen(
+    pong_output_state === 1.U && output_done && is_pong_writing
+  ) {
+    pong_output_state := 0.U
+  }
+
+  // output_counter for multi stage output for both ping and pong
   when(
     output_counter === 0.U && write_fire && (output_counter < (stages.U - 1.U))
   ) {
@@ -135,44 +228,64 @@ class BatchGemmSnaxTop(TCDMWritePorts: Int = 8) extends BatchGemm {
   }
 
   dontTouch(output_done)
+  // output key signals for both ping and pong
   output_start := new_output_fire
   output_done := output_counter === (stages.U - 1.U) && write_fire
 
-  // right shift the result data to support only output the lowest part of bits every time without changing the index
-  // storing io.data.c_o when it is valid for later output
-  when(write_fire && new_output_fire) {
-    output_reg := io.data.c_o >> (TCDMWritePorts * GemmConstant.TCDMDataWidth).U
-  }.elsewhen(!write_fire && new_output_fire) {
-    output_reg := io.data.c_o
-  }.elsewhen(write_fire) {
-    output_reg := output_reg >> (TCDMWritePorts * GemmConstant.TCDMDataWidth).U
-  }
-
-  // store the address and extra data for later output
-  when(new_output_fire) {
-    addr_c := io.ctrl.addr_c_o
+  // shift the ping/pong for writing to the TCDM
+  when(output_done) {
+    is_ping_writing := ~is_ping_writing
+    is_pong_writing := ~is_pong_writing
+  }.otherwise {
+    is_ping_writing := is_ping_writing
+    is_pong_writing := is_pong_writing
   }
 
   // set new_output_ready when it is not the output state
-  new_output_ready := !output_state
-  new_output_fire := new_output_ready && (gemm_write_valid_from_block_gemm)
-
+  output_reg_ready_ping := !ping_output_state
+  output_reg_ready_pong := !pong_output_state
   // give ready signal to block gemm
-  gemm_write_ready_o := new_output_ready
+  gemm_write_ready_o := (output_reg_ready_ping && is_ping_output_for_write_reg) || (output_reg_ready_pong && is_pong_output_for_write_reg)
 
-  // multi-stage output data and address
-  io.data.multi_stage_c_o := Mux(
-    new_output_fire,
-    io.data.c_o((TCDMWritePorts * GemmConstant.TCDMDataWidth) - 1, 0),
-    output_reg((TCDMWritePorts * GemmConstant.TCDMDataWidth) - 1, 0)
-  )
-  io.ctrl.addr_c_o := Mux(
-    new_output_fire,
-    block_gemm_addr_c_o,
-    addr_c + addrDelta.U * output_counter
-  )
+  // multi-stage output data and address according to the ping/pong
+  when(is_ping_writing) {
+    io.data.multi_stage_c_o := Mux(
+      ping_new_output_fire,
+      io.data.c_o((TCDMWritePorts * GemmConstant.TCDMDataWidth) - 1, 0),
+      data_c_reg_ping((TCDMWritePorts * GemmConstant.TCDMDataWidth) - 1, 0)
+    )
+    io.ctrl.addr_c_o := Mux(
+      ping_new_output_fire,
+      block_gemm_addr_c_o,
+      addr_c_reg_ping + addrDelta.U * output_counter
+    )
+  }.otherwise {
+    io.data.multi_stage_c_o := Mux(
+      pong_new_output_fire,
+      io.data.c_o((TCDMWritePorts * GemmConstant.TCDMDataWidth) - 1, 0),
+      data_c_reg_pong((TCDMWritePorts * GemmConstant.TCDMDataWidth) - 1, 0)
+    )
+    io.ctrl.addr_c_o := Mux(
+      pong_new_output_fire,
+      block_gemm_addr_c_o,
+      addr_c_reg_pong + addrDelta.U * output_counter
+    )
+  }
 
-  // not busy util all write finish
+  // indicating if the data in ping/pong buffer is valid. if valid, keep writing
+  when(ping_new_output_fire) {
+    output_reg_valid_ping := 1.B
+  }.elsewhen(output_done && is_ping_writing) {
+    output_reg_valid_ping := 0.B
+  }
+
+  when(pong_new_output_fire) {
+    output_reg_valid_pong := 1.B
+  }.elsewhen(output_done && is_pong_writing) {
+    output_reg_valid_pong := 0.B
+  }
+
+  // busy util all write finish
   io.ctrl.busy_o := controller.io.busy_o || io.ctrl.gemm_write_valid_o
   controller.io.start_do_i := io.ctrl.start_do_i && !io.ctrl.busy_o
 
@@ -185,23 +298,12 @@ class BatchGemmSnaxTop(TCDMWritePorts: Int = 8) extends BatchGemm {
 
   // below is for if not q_ready, keep sending read/write request
   read_fire := io.ctrl.gemm_read_valid_o && io.ctrl.read_mem_ready
-  write_fire := io.ctrl.gemm_write_valid_o && io.ctrl.write_mem_ready
-
   when(io.ctrl.gemm_read_valid_o && !read_fire) {
     keep_read := 1.B
   }.otherwise {
     keep_read := 0.B
   }
-
-  when(io.ctrl.gemm_write_valid_o && !write_fire) {
-    keep_write := 1.B
-  }.otherwise {
-    keep_write := 0.B
-  }
-
-  // giving output
   io.ctrl.gemm_read_valid_o := controller.io.gemm_read_valid_o || keep_read
-  io.ctrl.gemm_write_valid_o := new_output_fire || output_valid_multi_stages || keep_write
   io.ctrl.addr_a_o := Mux(
     controller.io.gemm_read_valid_o,
     controller.io.addr_a_o,
@@ -212,6 +314,10 @@ class BatchGemmSnaxTop(TCDMWritePorts: Int = 8) extends BatchGemm {
     controller.io.addr_b_o,
     addr_b
   )
+
+  write_fire := ping_write_fire || pong_write_fire
+
+  io.ctrl.gemm_write_valid_o := ((output_reg_valid_ping || ping_new_output_fire && is_ping_writing) || (output_reg_valid_pong || pong_new_output_fire && is_pong_writing))
 
   io.ctrl.perf_counter := perf_counter
 }

--- a/src/main/scala/gemm/GemmTCDMWritePorts.scala
+++ b/src/main/scala/gemm/GemmTCDMWritePorts.scala
@@ -18,7 +18,7 @@ class BatchGemmWithStallController extends BatchGemmController {
 
   // These two signal are used for generating new read request after the stall finishes
   val read_rsp_counter = RegInit(0.U(24.W))
-  val new_read_K = WireInit(false.B)
+  val new_read = WireInit(false.B)
 
   when(io.data_valid_i && io.busy_o) {
     read_rsp_counter := read_rsp_counter + 1.U
@@ -26,12 +26,11 @@ class BatchGemmWithStallController extends BatchGemmController {
     read_rsp_counter := 0.U
   }
 
-  // If K_read_counter === 0.U, it means the start of a new output matrix generation
   // If read_counter <= read_rsp_counter, it means the read request number is equal or less the read responds number
   // So another read request can be sent
-  new_read_K := K_read_counter === 0.U && read_counter <= read_rsp_counter
+  new_read := read_counter <= read_rsp_counter
 
-  io.gemm_read_valid_o := ((io.data_valid_i === 1.B || start_batch === 1.B || new_read_K === 1.B) && (!io.stalled_by_write) && (cstate === sREAD))
+  io.gemm_read_valid_o := ((io.data_valid_i === 1.B || start_batch === 1.B || new_read === 1.B) && (!io.stalled_by_write) && (cstate === sREAD))
 
 }
 

--- a/src/test/scala/gemm/TestBatchGemmSnaxTop.scala
+++ b/src/test/scala/gemm/TestBatchGemmSnaxTop.scala
@@ -21,7 +21,7 @@ class BatchGemmSnaxTopWrapper(TCDMWritePorts: Int) extends Module {
 
   data_valid_i_from_tcdm := RegNext(gemm.io.ctrl.gemm_read_valid_o)
   gemm.io.ctrl.data_valid_i := data_valid_i_from_tcdm
-  // tcdm ready always asserted to minic no contention
+  // tcdm ready always asserted to mimic no contention
   gemm.io.ctrl.read_mem_ready := 1.B
   gemm.io.ctrl.write_mem_ready := 1.B
   io.perf_counter := gemm.io.ctrl.perf_counter
@@ -77,28 +77,31 @@ class BatchGemmSnaxTopWrapperManualTest
     }
 
     // matrix size various corner case test
+    // smallest test case
     CornerCaseTest(1, 1, 1, 1)
 
-    CornerCaseTest(1, 1, 2, 1)
-    CornerCaseTest(1, 2, 1, 1)
-    CornerCaseTest(1, 1, 1, 2)
-
+    // tests with one smallest size which is 1 in each dimension
     CornerCaseTest(1, 2, 1, 2)
     CornerCaseTest(1, 1, 2, 2)
     CornerCaseTest(1, 2, 2, 1)
     CornerCaseTest(2, 1, 2, 2)
+
+    // tests with different number of smallest size which is 1 in each dimension
+    CornerCaseTest(1, 1, 2, 1)
+    CornerCaseTest(2, 2, 1, 1)
+    CornerCaseTest(2, 1, 2, 1)
+    CornerCaseTest(2, 1, 1, 2)
     CornerCaseTest(2, 2, 2, 2)
 
-    CornerCaseTest(1, 3, 2, 4)
-    CornerCaseTest(1, 3, 1, 4)
-    CornerCaseTest(1, 3, 4, 2)
-    CornerCaseTest(1, 3, 4, 4)
-
-    CornerCaseTest(1, 3, 5, 2)
+    // for performance analysis, in this test, the computation cycle is 128
+    // there should only be 1 extra cycle for the first read request
+    // and the extra cycle for outputting the last result, which is 4 for tcdm write port = 8 and is 2 for tcdm write port = 16
     CornerCaseTest(1, 4, 8, 4)
+
+    // extreme test for K = 1 which gives most pressure to the output part
     CornerCaseTest(1, 4, 1, 4)
     CornerCaseTest(1, 5, 1, 5)
-    CornerCaseTest(1, 4, 4, 4)
+    CornerCaseTest(1, 3, 1, 4)
 
     emitVerilog(
       new BatchGemmSnaxTopWrapper(GemmConstant.TCDMWritePorts),


### PR DESCRIPTION
In this PR, we refactored the double buffering to enhance the performance. Previously, there was only one buffer to buffer the output to don't stall the read request. Now we have real two buffers to buffer the output, aka, the real double buffering strategy, to further reduce read request stall.