### PR TITLE
Add substraction a and b

### DIFF
--- a/src/main/scala/gemm/BlockGemm.scala
+++ b/src/main/scala/gemm/BlockGemm.scala
@@ -7,6 +7,8 @@ class BlockGemmControllerIO extends Bundle {
   val M_i = Input(UInt(GemmConstant.sizeConfigWidth.W))
   val K_i = Input(UInt(GemmConstant.sizeConfigWidth.W))
   val N_i = Input(UInt(GemmConstant.sizeConfigWidth.W))
+  val subtraction_a_i = Input(UInt(GemmConstant.dataWidthA.W))
+  val subtraction_b_i = Input(UInt(GemmConstant.dataWidthB.W))
   val start_do_i = Input(Bool())
   val data_valid_o = Input(Bool())
   val data_valid_i = Input(Bool())
@@ -21,6 +23,9 @@ class BlockGemmControllerIO extends Bundle {
   val addr_a_o = Output(UInt(GemmConstant.addrWidth.W))
   val addr_b_o = Output(UInt(GemmConstant.addrWidth.W))
   val addr_c_o = Output(UInt(GemmConstant.addrWidth.W))
+
+  val subtraction_a_o = Output(UInt(GemmConstant.dataWidthA.W))
+  val subtraction_b_o = Output(UInt(GemmConstant.dataWidthB.W))
 
   val busy_o = Output(Bool())
   val accumulate_i = Output(Bool())
@@ -38,6 +43,8 @@ class BlockGemmController extends Module {
   val M = RegInit(0.U(GemmConstant.sizeConfigWidth.W))
   val K = RegInit(0.U(GemmConstant.sizeConfigWidth.W))
   val N = RegInit(0.U(GemmConstant.sizeConfigWidth.W))
+  val a = RegInit(0.U(GemmConstant.dataWidthA.W))
+  val b = RegInit(0.U(GemmConstant.dataWidthB.W))
 
   val ptr_addr_a = RegInit(0.U(GemmConstant.addrWidth.W))
   val ptr_addr_b = RegInit(0.U(GemmConstant.addrWidth.W))
@@ -102,6 +109,8 @@ class BlockGemmController extends Module {
     M := io.M_i
     N := io.N_i
     K := io.K_i
+    a := io.subtraction_a_i
+    b := io.subtraction_b_i
     ptr_addr_a := io.ptr_addr_a_i
     ptr_addr_b := io.ptr_addr_b_i
     ptr_addr_c := io.ptr_addr_c_i
@@ -113,6 +122,8 @@ class BlockGemmController extends Module {
     M := 0.U
     N := 0.U
     K := 0.U
+    a := 0.U
+    b := 0.U
     ptr_addr_a := 0.U
     ptr_addr_b := 0.U
     ptr_addr_c := 0.U
@@ -196,6 +207,9 @@ class BlockGemmController extends Module {
   io.addr_c_o := ptr_addr_c + (GemmConstant.baseAddrIncrementC.U) * (M_write_counter * N + N_write_counter)
 
   io.perf_counter := perf_counter
+
+  io.subtraction_a_o := a
+  io.subtraction_b_o := b
 }
 
 // The BlockGemm's control port declaration. Detailed explanation of these ports can be found in the README
@@ -203,6 +217,8 @@ class BlockGemmCtrlIO extends Bundle {
   val M_i = Input(UInt(GemmConstant.sizeConfigWidth.W))
   val K_i = Input(UInt(GemmConstant.sizeConfigWidth.W))
   val N_i = Input(UInt(GemmConstant.sizeConfigWidth.W))
+  val subtraction_a_i = Input(UInt(GemmConstant.dataWidthA.W))
+  val subtraction_b_i = Input(UInt(GemmConstant.dataWidthB.W))
 
   val start_do_i = Input(Bool())
   val data_valid_i = Input(Bool())
@@ -263,6 +279,9 @@ class BlockGemm extends Module {
   controller.io.M_i <> io.ctrl.M_i
   controller.io.K_i <> io.ctrl.K_i
   controller.io.N_i <> io.ctrl.N_i
+  controller.io.subtraction_a_i <> io.ctrl.subtraction_a_i
+  controller.io.subtraction_b_i <> io.ctrl.subtraction_b_i
+
   controller.io.start_do_i <> io.ctrl.start_do_i
   controller.io.data_valid_i <> io.ctrl.data_valid_i
   controller.io.ptr_addr_a_i <> io.ctrl.ptr_addr_a_i
@@ -286,6 +305,10 @@ class BlockGemm extends Module {
 
   gemm_array.io.data.a_i <> io.data.a_i
   gemm_array.io.data.b_i <> io.data.b_i
+
+  gemm_array.io.subtraction_a_i <> io.ctrl.subtraction_a_i
+  gemm_array.io.subtraction_b_i <> io.ctrl.subtraction_b_i
+
   io.data.c_o <> (gemm_array.io.data.c_o)
 
   gemm_array.io.data_valid_i := io.ctrl.data_valid_i

--- a/src/main/scala/gemm/BlockGemm.scala
+++ b/src/main/scala/gemm/BlockGemm.scala
@@ -306,8 +306,8 @@ class BlockGemm extends Module {
   gemm_array.io.data.a_i <> io.data.a_i
   gemm_array.io.data.b_i <> io.data.b_i
 
-  gemm_array.io.subtraction_a_i <> io.ctrl.subtraction_a_i
-  gemm_array.io.subtraction_b_i <> io.ctrl.subtraction_b_i
+  gemm_array.io.subtraction_a_i <> controller.io.subtraction_a_o
+  gemm_array.io.subtraction_b_i <> controller.io.subtraction_b_o
 
   io.data.c_o <> (gemm_array.io.data.c_o)
 

--- a/src/snax_gemm_wrapper.sv
+++ b/src/snax_gemm_wrapper.sv
@@ -59,8 +59,11 @@ module snax_gemm_wrapper #(
   // performance counter csr for how many cycle used for finishing GEMM operation
   localparam int unsigned PerfCounterCsr = 32'h3cd;
 
+  // substraction CSR
+  localparam int unsigned SubstractionCsr = 32'h3ce;
+
   // state csr, indicating when to start GEMM and if the GEMM is busy
-  localparam int unsigned StateCsr = 32'h3ce;
+  localparam int unsigned StateCsr = 32'h3cf;
 
   // Local parameters for input and output sizes
   localparam int unsigned InputTcdmPorts = 16;
@@ -71,8 +74,12 @@ module snax_gemm_wrapper #(
   localparam int unsigned AddrWidth = 32;
   localparam int unsigned SizeConfigWidth = 8;
 
+  // Local parameters for subtraction a and subtraction b
+  localparam int unsigned dataWidthA = 8;
+  localparam int unsigned dataWidthB = 8;
+
   // CSR wires
-  localparam int unsigned RegNum = 15;
+  localparam int unsigned RegNum = 16;
   localparam int unsigned CsrAddrOFfset = 32'h3c0;
 
   logic      [                     31:0] CSR                         [RegNum];
@@ -129,6 +136,10 @@ module snax_gemm_wrapper #(
   logic      [          AddrWidth - 1:0] io_ctrl_addr_a_o;
   logic      [          AddrWidth - 1:0] io_ctrl_addr_b_o;
   logic      [          AddrWidth - 1:0] io_ctrl_addr_c_o;
+
+  // substraction a and b for gemm
+  logic [dataWidthA - 1:0] substraction_a;
+  logic [dataWidthB - 1:0] substraction_b;
 
   // local input matrix buffer
   logic      [InputMatrixSize * 2 - 1:0] data_reg;
@@ -261,6 +272,9 @@ module snax_gemm_wrapper #(
   assign io_ctrl_K_i = CSR[MatrixSizeCsr-CsrAddrOFfset][15:8];
   assign io_ctrl_N_i = CSR[MatrixSizeCsr-CsrAddrOFfset][7:0];
 
+  assign substraction_a = CSR[SubstractionCsr - CsrAddrOFfset][7:0];
+  assign substraction_b = CSR[SubstractionCsr - CsrAddrOFfset][15:8];
+
   assign io_ctrl_ptr_addr_a_i = CSR[AddrACsr-CsrAddrOFfset];
   assign io_ctrl_ptr_addr_b_i = CSR[AddrBCsr-CsrAddrOFfset];
   assign io_ctrl_ptr_addr_c_i = CSR[AddrCCsr-CsrAddrOFfset];
@@ -284,6 +298,8 @@ module snax_gemm_wrapper #(
       .io_ctrl_M_i(io_ctrl_M_i),
       .io_ctrl_K_i(io_ctrl_K_i),
       .io_ctrl_N_i(io_ctrl_N_i),
+      .io_ctrl_subtraction_a_i(substraction_a),
+      .io_ctrl_subtraction_b_i(substraction_b),
       .io_ctrl_start_do_i(io_ctrl_start_do_i),
       .io_ctrl_data_valid_i(io_ctrl_data_valid_i),
       .io_ctrl_ptr_addr_a_i(io_ctrl_ptr_addr_a_i),

--- a/src/test/scala/gemm/MatrixLibBase.scala
+++ b/src/test/scala/gemm/MatrixLibBase.scala
@@ -32,6 +32,11 @@ object MatrixLibBase {
     (random_matrix_A, random_matrix_B)
   }
 
+  def GenRandomSubtractionValue() = {
+    val rand = new scala.util.Random
+    (rand.between(0, 127).toByte, rand.between(0, 127).toByte)
+  }
+
   // This function prints the matrix with Byte data type
   def PrintMatrixByte_1D(
       meshRow: Int,
@@ -142,7 +147,7 @@ object MatrixLibBase {
       B: Array[Int]
   ) = {
     for (i <- 0 until Len) {
-      // println(A(i),B(i))
+      // println(A(i), B(i))
       assert(A(i) == B(i))
     }
   }
@@ -165,7 +170,9 @@ object MatrixLibBase {
       tileSize: Int,
       meshCol: Int,
       A: Array[Byte],
-      B: Array[Byte]
+      B: Array[Byte],
+      subtraction_a: Byte,
+      subtraction_b: Byte
   ): Array[Int] = {
     val golden = Array.ofDim[Int](meshRow * meshCol)
     for (i <- 0 until meshRow) {
@@ -177,7 +184,9 @@ object MatrixLibBase {
           /* assuming the matrix B is arranged as N data layout */
           golden(i * meshCol + j) = golden(
             i * meshCol + j
-          ) + A(i * tileSize + k) * B(k + j * tileSize)
+          ) + (A(i * tileSize + k) - subtraction_a) * (B(
+            k + j * tileSize
+          ) - subtraction_b)
         }
         // println("golden",golden(i * meshCol + j))
       }

--- a/src/test/scala/gemm/MatrixLibLarge.scala
+++ b/src/test/scala/gemm/MatrixLibLarge.scala
@@ -162,7 +162,9 @@ object MatrixLibBlock {
             B.slice(
               (k + j * K) * GemmConstant.tileSize * GemmConstant.meshCol,
               (k + j * K + 1) * GemmConstant.tileSize * GemmConstant.meshCol
-            )
+            ),
+            0,
+            0
           )
           submatrx_temp = golden
             .slice(

--- a/src/test/scala/gemm/TestBaseGemm.scala
+++ b/src/test/scala/gemm/TestBaseGemm.scala
@@ -31,13 +31,19 @@ class GemmArrayRandomTest
           val random_matrix_A = RandomMatrixs._1
           val random_matrix_B = RandomMatrixs._2
 
+          val RandomSubtractionValue = MatrixLibBase.GenRandomSubtractionValue()
+          val subtraction_a = RandomSubtractionValue._1
+          val subtraction_b = RandomSubtractionValue._2
+
           // Generate golden result data for verification
           val golden_array = MatrixLibBase.MatrixMul_1D(
             GemmConstant.meshRow,
             GemmConstant.tileSize,
             GemmConstant.meshCol,
             random_matrix_A,
-            random_matrix_B
+            random_matrix_B,
+            subtraction_a,
+            subtraction_b
           )
           /* Translate data array to big bus for Gemm module input */
           val RandomBigBuses =
@@ -54,6 +60,9 @@ class GemmArrayRandomTest
           // Invoke data_valid_i to send the test data
           dut.io.data_valid_i.poke(1.U)
           dut.io.data_ready_o.poke(true.B)
+
+          dut.io.subtraction_a_i.poke(subtraction_a)
+          dut.io.subtraction_b_i.poke(subtraction_b)
           dut.io.data.a_i.poke(RandomBigBus_A)
           dut.io.data.b_i.poke(RandomBigBus_B)
 


### PR DESCRIPTION
In this PR, we extend the gemm feature to support C = (A-a)*(B-b) described in https://github.com/KULeuven-MICAS/snax-mlir/issues/37. Specifically, we add/modify:
* subtraction logic in gemm computation
* the hardware unit test
* an subtraction value CSR in the wrapper module