### PR TITLE
Add csr manager for newgemm

### DIFF
--- a/src/main/scala/gemm/BareBlockGemm.scala
+++ b/src/main/scala/gemm/BareBlockGemm.scala
@@ -190,6 +190,8 @@ object BareBlockGemm extends App {
   )
 }
 
+// adds the csrManager for new gemm to be integrated with streamer.
+// gives the new gemm the same interface to SNAX as streamer (the csrReqRspIO).
 class BareBlockGemmTop() extends Module with RequireAsyncReset {
   val io = IO(new Bundle {
     val csr = new CsrReqRspIO(GemmConstant.csrAddrWidth)
@@ -201,18 +203,29 @@ class BareBlockGemmTop() extends Module with RequireAsyncReset {
   )
   val bareBlockGemm = Module(new BareBlockGemm())
 
+  // io.csr and csrManager input connection
   csrManager.io.csr_config_in <> io.csr
 
+  // csrManager output and bare block gemm control port connection
+  // control signals
   bareBlockGemm.io.ctrl.valid := csrManager.io.csr_config_out.valid
   csrManager.io.csr_config_out.ready := bareBlockGemm.io.ctrl.ready
+
+  // the first csr contains the outermost loop bound which is M
   bareBlockGemm.io.ctrl.bits.M_i := csrManager.io.csr_config_out.bits(0)
+  // the second csr contains the next inside loop bound which is N
   bareBlockGemm.io.ctrl.bits.K_i := csrManager.io.csr_config_out.bits(1)
+  // the third csr contains the innermost loop bound which is K
   bareBlockGemm.io.ctrl.bits.N_i := csrManager.io.csr_config_out.bits(2)
+
+  // the forth csr contains the subtraction_a value
   bareBlockGemm.io.ctrl.bits.subtraction_a_i :=
     csrManager.io.csr_config_out.bits(3)
+  // the fifth csr contains the subtraction_b value
   bareBlockGemm.io.ctrl.bits.subtraction_b_i :=
     csrManager.io.csr_config_out.bits(4)
 
+  // io.data and bare block gemm data ports connection
   io.data <> bareBlockGemm.io.data
 
 }

--- a/src/main/scala/gemm/CsrManager.scala
+++ b/src/main/scala/gemm/CsrManager.scala
@@ -1,0 +1,143 @@
+package gemm
+
+import chisel3._
+import chisel3.util._
+
+/** simplified csr read/write cmd
+  *
+  * @param csrAddrWidth
+  *   csr registers address width
+  */
+class CsrReq(csrAddrWidth: Int) extends Bundle {
+  val data = UInt(32.W)
+  val addr = UInt(csrAddrWidth.W)
+  val write = Bool()
+}
+
+class CsrRsp extends Bundle {
+  val data = UInt(32.W)
+}
+
+/** This class represents the csr input and output ports of the streamer top
+  * module
+  *
+  * @param csrAddrWidth
+  *   csr registers address width
+  */
+class CsrReqRspIO(csrAddrWidth: Int) extends Bundle {
+
+  val req = Flipped(Decoupled(new CsrReq(csrAddrWidth)))
+  val rsp = Decoupled(new CsrRsp)
+
+}
+
+/** This class represents the input and output ports of the CsrManager module.
+  * The input is connected to the SNAX CSR port. The output is connected to the
+  * streamer configuration port.
+  * @param csrNum
+  *   the number of csr registers
+  * @param csrAddrWidth
+  *   the width of the address
+  */
+class CsrManagerIO(
+    csrNum: Int,
+    csrAddrWidth: Int
+) extends Bundle {
+
+  val csr_config_in = new CsrReqRspIO(csrAddrWidth)
+  val csr_config_out = Decoupled(Vec(csrNum, UInt(32.W)))
+
+}
+
+/** This class represents the CsrManager module. It contains the csr registers
+  * and the read and write control logic.
+  * @param csrNum
+  *   the number of csr registers
+  * @param csrAddrWidth
+  *   the width of the address
+  */
+class CsrManager(
+    csrNum: Int,
+    csrAddrWidth: Int
+) extends Module
+    with RequireAsyncReset {
+
+  val io = IO(new CsrManagerIO(csrNum, csrAddrWidth))
+
+  // generate a vector of registers to store the csr state
+  val csr = RegInit(VecInit(Seq.fill(csrNum)(0.U(32.W))))
+
+  // read and write csr cmd
+  val read_csr = io.csr_config_in.req.fire && !io.csr_config_in.req.bits.write
+  val write_csr = io.csr_config_in.req.fire && io.csr_config_in.req.bits.write
+
+  // keep sending response to a read request until we receive the response ready signal
+  val keep_sending_csr_rsp = RegNext(
+    io.csr_config_in.rsp.valid && !io.csr_config_in.rsp.ready
+  )
+  // a register to store the read request response data until the request is successful
+  val csr_rsp_data_reg = RegInit(0.U(32.W))
+
+  // store the csr data for later output because the address only valid when io.csr.fire
+  csr_rsp_data_reg := Mux(
+    read_csr,
+    csr(io.csr_config_in.req.bits.addr),
+    csr_rsp_data_reg
+  )
+
+  // streamer configuration valid signal
+  val config_valid = WireInit(0.B)
+
+  // check if the csr address overflow (access certain csr that doesn't exist)
+  def startCsrAddr = (csrNum - 1).U
+
+  when(io.csr_config_in.req.fire) {
+
+    assert(
+      io.csr_config_in.req.bits.addr <= startCsrAddr,
+      "csr address overflow!"
+    )
+
+  }
+
+  // write req
+  when(write_csr) {
+    csr(io.csr_config_in.req.bits.addr) := io.csr_config_in.req.bits.data
+  }
+
+  // handle read requests: keep sending response data until the request succeeds
+  when(read_csr) {
+    io.csr_config_in.rsp.bits.data := csr(io.csr_config_in.req.bits.addr)
+    io.csr_config_in.rsp.valid := 1.B
+  }.elsewhen(keep_sending_csr_rsp) {
+    io.csr_config_in.rsp.bits.data := csr_rsp_data_reg
+    io.csr_config_in.rsp.valid := 1.B
+  }.otherwise {
+    io.csr_config_in.rsp.valid := 0.B
+    io.csr_config_in.rsp.bits.data := 0.U
+  }
+
+  // we are ready for a new request if two conditions hold:
+  // if we write to the config_valid register (the last one), the streamer must not be busy (io.csr_config_out.ready)
+  // if there is a read request in progress, we only accept new write requests
+  io.csr_config_in.req.ready := (io.csr_config_out.ready || !(io.csr_config_in.req.bits.addr === startCsrAddr)) && (!keep_sending_csr_rsp || io.csr_config_in.req.bits.write)
+
+  // a write/read to the last csr means the config is valid
+  config_valid := io.csr_config_in.req.fire && (io.csr_config_in.req.bits.addr === startCsrAddr)
+
+  // signals connected to the output ports
+  io.csr_config_out.bits <> csr
+  io.csr_config_out.valid <> config_valid
+
+}
+
+// Scala main function for generating CsrManager system verilog file
+object CsrManager extends App {
+  emitVerilog(
+    new CsrManager(
+      GemmConstant.csrNum,
+      GemmConstant.csrAddrWidth
+    ),
+    Array("--target-dir", "generated/csr_manager")
+  )
+}

--- a/src/main/scala/gemm/Parameter.scala
+++ b/src/main/scala/gemm/Parameter.scala
@@ -28,4 +28,7 @@ object GemmConstant {
   def idealTCDMWritePorts = 32
   def TCDMDataWidth = 64
 
+  def csrNum: Int = 5
+  def csrAddrWidth: Int = 32
+
 }


### PR DESCRIPTION
This RP,
* adds the csrManager for new gemm to be integrated with streamer. 
* give the new gemm the same interface to SNAX as streamer (the csrReqRspIO).

As shown in the figure below, 

![image](https://github.com/KULeuven-MICAS/snax-gemm/assets/143962462/37067c6a-6130-4b67-9b56-7ece86cbcdc3)


The source code is the same as csrManager in https://github.com/KULeuven-MICAS/snax-streamer/blob/main/src/main/scala/streamer/CsrManager.scala