### PR TITLE
Change addr gen

### DIFF
--- a/src/main/scala/gemm/BatchGemm.scala
+++ b/src/main/scala/gemm/BatchGemm.scala
@@ -29,7 +29,7 @@ class BatchGemmController extends BlockGemmController {
   override lazy val io = IO(new BatchGemmControllerIO())
 
   // Registers to store the configurations
-  val Bacth = RegInit(0.U(GemmConstant.sizeConfigWidth.W))
+  val Batch = RegInit(0.U(GemmConstant.sizeConfigWidth.W))
 
   val strideinnermost_A = RegInit(0.U(GemmConstant.addrWidth.W))
   val strideinnermost_B = RegInit(0.U(GemmConstant.addrWidth.W))
@@ -44,8 +44,8 @@ class BatchGemmController extends BlockGemmController {
   val stride_C = RegInit(0.U(GemmConstant.addrWidth.W))
 
   // Counters for tracing the batch
-  val batch_read_counter = WireInit(0.U(GemmConstant.sizeConfigWidth.W))
-  val batch_write_counter = WireInit(0.U(GemmConstant.sizeConfigWidth.W))
+  val batchReadCounter = WireInit(0.U(GemmConstant.sizeConfigWidth.W))
+  val batchWriteCounter = WireInit(0.U(GemmConstant.sizeConfigWidth.W))
 
   // Signal for start a new batch
   val start_batch = WireInit(false.B)
@@ -54,9 +54,13 @@ class BatchGemmController extends BlockGemmController {
   val read_tcdm_done_once = WireInit(false.B)
   val gemm_done_once = WireInit(false.B)
 
+  val batchLoopBounds = WireInit(
+    VecInit(Seq.fill(4)(0.U(GemmConstant.sizeConfigWidth.W)))
+  )
+
   // Store the configurations when io.start_do_i && !io.busy_o
   when(io.start_do_i && !io.busy_o) {
-    Bacth := io.Batch_i
+    Batch := io.Batch_i
     stride_A := io.strideA_i
     stride_B := io.strideB_i
     stride_C := io.strideC_i
@@ -68,7 +72,7 @@ class BatchGemmController extends BlockGemmController {
     strideinnermost_C := io.strideinnermost_C_i
     assert(io.Batch_i =/= 0.U, "B == 0, invalid configuration!")
   }.elsewhen(cstate === sIDLE) {
-    Bacth := 0.U
+    Batch := 0.U
     stride_A := 0.U
     stride_B := 0.U
     stride_C := 0.U
@@ -82,40 +86,43 @@ class BatchGemmController extends BlockGemmController {
 
   // Counters for generating the right addresses for block matrix multiplication
   // with the consideration of batch
-  M_read_counter := (read_counter - batch_read_counter * M * K * N) / (K * N)
-  K_read_counter := ((read_counter - batch_read_counter * M * K * N) % (K * N)) % K
-  N_read_counter := ((read_counter - batch_read_counter * M * K * N) % (K * N)) / K
+  batchLoopBounds(0) := K
+  batchLoopBounds(1) := N
+  batchLoopBounds(2) := M
+  batchLoopBounds(3) := Batch
+  val readBatchLoopCounters =
+    loopCounterGen(cstate =/= sIDLE, io.gemm_read_valid_o, batchLoopBounds)
+  K_read_counter := readBatchLoopCounters(0)
+  N_read_counter := readBatchLoopCounters(1)
+  M_read_counter := readBatchLoopCounters(2)
+  batchReadCounter := readBatchLoopCounters(3)
 
-  M_write_counter := ((write_counter - batch_write_counter * M * K * N) / K) / N
-  K_write_counter := (write_counter - batch_write_counter * M * K * N) % K
-  N_write_counter := ((write_counter - batch_write_counter * M * K * N) / K) % N
-
-  batch_read_counter := Mux(cstate =/= sIDLE, (read_counter) / (M * K * N), 0.U)
-  batch_write_counter := Mux(
-    cstate =/= sIDLE,
-    (write_counter) / (M * K * N),
-    0.U
-  )
+  val writeBatchLoopCounters =
+    loopCounterGen(cstate =/= sIDLE, io.data_valid_o, batchLoopBounds)
+  K_write_counter := writeBatchLoopCounters(0)
+  N_write_counter := writeBatchLoopCounters(1)
+  M_write_counter := writeBatchLoopCounters(2)
+  batchWriteCounter := writeBatchLoopCounters(3)
 
   // Intermediate or output control signals generation according to the counters
-  read_tcdm_done_once := (M_read_counter === (M - 1.U)) && (N_read_counter === (N - 1.U)) && (K_read_counter === (K - 1.U)) && (batch_read_counter =/= Bacth - 1.U) && cstate =/= sIDLE && io.gemm_read_valid_o
-  read_tcdm_done := (M_read_counter === (M - 1.U)) && (N_read_counter === (N - 1.U)) && (K_read_counter === (K - 1.U)) && (batch_read_counter === Bacth - 1.U) && cstate =/= sIDLE && io.gemm_read_valid_o
+  read_tcdm_done_once := (M_read_counter === (M - 1.U)) && (N_read_counter === (N - 1.U)) && (K_read_counter === (K - 1.U)) && (batchReadCounter =/= Batch - 1.U) && cstate =/= sIDLE && io.gemm_read_valid_o
+  read_tcdm_done := (M_read_counter === (M - 1.U)) && (N_read_counter === (N - 1.U)) && (K_read_counter === (K - 1.U)) && (batchReadCounter === Batch - 1.U) && cstate =/= sIDLE && io.gemm_read_valid_o
 
-  gemm_done := (M_write_counter === (M - 1.U)) && (N_write_counter === (N - 1.U)) && (K_write_counter === (K - 1.U)) && (batch_write_counter === Bacth - 1.U) && cstate =/= sIDLE && io.gemm_write_valid_o
-  gemm_done_once := (M_write_counter === (M - 1.U)) && (N_write_counter === (N - 1.U)) && (K_write_counter === (K - 1.U)) && (batch_write_counter =/= Bacth - 1.U) && cstate =/= sIDLE && io.gemm_write_valid_o
+  gemm_done := (M_write_counter === (M - 1.U)) && (N_write_counter === (N - 1.U)) && (K_write_counter === (K - 1.U)) && (batchWriteCounter === Batch - 1.U) && cstate =/= sIDLE && io.gemm_write_valid_o
+  gemm_done_once := (M_write_counter === (M - 1.U)) && (N_write_counter === (N - 1.U)) && (K_write_counter === (K - 1.U)) && (batchWriteCounter =/= Batch - 1.U) && cstate =/= sIDLE && io.gemm_write_valid_o
 
   io.gemm_read_valid_o := (start_do === 1.B || start_batch === 1.B) || (io.data_valid_i && (cstate === sREAD))
   io.gemm_write_valid_o := (write_valid_counter === K - 1.U) && io.data_valid_o && cstate =/= sIDLE
   io.accumulate_i := (accumulate_counter =/= K - 1.U && io.data_valid_i === 1.B)
 
-  start_batch := (M_read_counter === (0.U)) && (N_read_counter === (0.U)) && (K_read_counter === (0.U)) && (batch_read_counter =/= Bacth - 1.U) && cstate === sREAD
+  start_batch := (M_read_counter === (0.U)) && (N_read_counter === (0.U)) && (K_read_counter === (0.U)) && (batchReadCounter =/= Batch - 1.U) && cstate === sREAD
 
   io.busy_o := (cstate =/= sIDLE)
 
   // Address generation
-  io.addr_a_o := ptr_addr_a + batch_read_counter * stride_A + M_read_counter * ld_A + strideinnermost_A * (K_read_counter)
-  io.addr_b_o := ptr_addr_b + batch_read_counter * stride_B + N_read_counter * ld_B + strideinnermost_B * (K_read_counter)
-  io.addr_c_o := ptr_addr_c + batch_write_counter * stride_C + M_write_counter * ld_C + strideinnermost_C * (N_write_counter)
+  io.addr_a_o := ptr_addr_a + batchReadCounter * stride_A + M_read_counter * ld_A + strideinnermost_A * (K_read_counter)
+  io.addr_b_o := ptr_addr_b + batchReadCounter * stride_B + N_read_counter * ld_B + strideinnermost_B * (K_read_counter)
+  io.addr_c_o := ptr_addr_c + batchWriteCounter * stride_C + M_write_counter * ld_C + strideinnermost_C * (N_write_counter)
 }
 
 // The BatchGemm's control port declaration.


### PR DESCRIPTION
In this PR, we
* change the address generation mechanism from a standalone counter for all the loops (using % and / to calculate the index for each loop) to maintain sub-counters for each loop.
* change `Bacth` typo to `Batch`
* rename `batch_read_counter`  / `batch_write_counter`  to `batchReadCounter`  / `batchReadCounter` .
