### PR TITLE
Rm result reg

### DIFF
--- a/src/main/scala/gemm/BatchGemm.scala
+++ b/src/main/scala/gemm/BatchGemm.scala
@@ -113,7 +113,7 @@ class BatchGemmController extends BlockGemmController {
 
   io.gemm_read_valid_o := (start_do === 1.B || start_batch === 1.B) || (io.data_valid_i && (cstate === sREAD))
   io.gemm_write_valid_o := (write_valid_counter === K - 1.U) && io.data_valid_o && cstate =/= sIDLE
-  io.accumulate_i := (accumulate_counter =/= K - 1.U && io.data_valid_i === 1.B)
+  io.accumulate_i := (accumulate_counter =/= 0.U && io.data_valid_i === 1.B)
 
   start_batch := (M_read_counter === (0.U)) && (N_read_counter === (0.U)) && (K_read_counter === (0.U)) && (batchReadCounter =/= Batch - 1.U) && cstate === sREAD
 

--- a/src/main/scala/gemm/BatchGemm.scala
+++ b/src/main/scala/gemm/BatchGemm.scala
@@ -112,8 +112,6 @@ class BatchGemmController extends BlockGemmController {
   gemm_done_once := (M_write_counter === (M - 1.U)) && (N_write_counter === (N - 1.U)) && (K_write_counter === (K - 1.U)) && (batchWriteCounter =/= Batch - 1.U) && cstate =/= sIDLE && io.gemm_write_valid_o
 
   io.gemm_read_valid_o := (start_do === 1.B || start_batch === 1.B) || (io.data_valid_i && (cstate === sREAD))
-  io.gemm_write_valid_o := (write_valid_counter === K - 1.U) && io.data_valid_o && cstate =/= sIDLE
-  io.accumulate_i := (accumulate_counter =/= 0.U && io.data_valid_i === 1.B)
 
   start_batch := (M_read_counter === (0.U)) && (N_read_counter === (0.U)) && (K_read_counter === (0.U)) && (batchReadCounter =/= Batch - 1.U) && cstate === sREAD
 

--- a/src/main/scala/gemm/BlockGemm.scala
+++ b/src/main/scala/gemm/BlockGemm.scala
@@ -256,7 +256,7 @@ class BlockGemmController extends Module with RequireAsyncReset {
 
   io.gemm_read_valid_o := (start_do === 1.B) || (io.data_valid_i && cstate === sREAD)
   io.gemm_write_valid_o := (write_valid_counter === K - 1.U) && io.data_valid_o && cstate =/= sIDLE
-  io.accumulate_i := (accumulate_counter =/= K - 1.U && (io.data_valid_i === 1.B))
+  io.accumulate_i := (accumulate_counter =/= 0.U && (io.data_valid_i === 1.B))
 
   io.busy_o := (cstate =/= sIDLE)
 


### PR DESCRIPTION
In this PR, we 
* remove the `result_reg ` to save the area. We reuse the `accumulation_reg` for the result store.
* remove duplicated two wires.