### PR TITLE
fix output valid bug

### DIFF
--- a/src/main/scala/gemm/BareBlockGemm.scala
+++ b/src/main/scala/gemm/BareBlockGemm.scala
@@ -204,7 +204,7 @@ class BareBlockGemm extends Module with RequireAsyncReset {
 
   // gemm output signals
   io.data.c_o.bits := gemm_array.io.data.c_o
-  io.data.c_o.valid := (write_valid_counter === K - 1.U) && gemm_output_fire && cstate =/= sIDLE
+  io.data.c_o.valid := (write_valid_counter === K - 1.U) && gemm_array.io.c_valid_o && cstate =/= sIDLE
 
 }
 


### PR DESCRIPTION
The `output_valid` signal was only set if the `output_ready` signal is set. This is not necessary and resulted in a deadlock when using streamers with a fifo depth of 0, as here the `output_ready` can depend on the `output_valid` signal.