### PR TITLE
Modify sizeConfigWidthto 32

### DIFF
--- a/src/main/scala/gemm/Parameter.scala
+++ b/src/main/scala/gemm/Parameter.scala
@@ -17,7 +17,7 @@ object GemmConstant {
   def meshCol = 8
 
   def addrWidth = 32
-  def sizeConfigWidth = 16
+  def sizeConfigWidth = 32
 
   def dataWidthPerAddr = 8
   def baseAddrIncrementA =


### PR DESCRIPTION
In this PR, we change the sizeConfigWidth for `M, K, N` configurations to 32 as now we assgin one CSR for each configuration and the CSR width of the RISC-V is 32.